### PR TITLE
Don't mutate caller's T in mpdist_profile (B1)

### DIFF
--- a/src/mpdist.jl
+++ b/src/mpdist.jl
@@ -37,7 +37,7 @@ function mpdist_profile(T::AbstractVector{TT},S::Int, m::Int, d::DT = ZEuclidean
     SlidingDistancesBase.DSP.FFTW.set_num_threads(1)
     n = length(T)
     pad = S * ceil(Int, n / S) - n
-    append!(T,zeros(TT, pad)) # vcat was not type stable
+    T = append!(copy(T), zeros(TT, pad)) # copy() to avoid mutating caller; vcat was not type stable
     N = S-m+1
     D = Matrix{float(TT)}(undef, length(T)-m+1, N)
     sliding_means = similar(D)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,6 +162,13 @@ end
        snips = snippets(T, 2, 50, m=5)
        @test_nowarn plot(snips)
 
+       # Regression test: mpdist_profile / snippets must not mutate the caller's T.
+       T_in = [A; B]
+       T_ref = copy(T_in)
+       mpdist_profile(T_in, 50, 5)
+       @test T_in == T_ref
+       snippets(T_in, 2, 50, m=5)
+       @test T_in == T_ref
    end
 
 


### PR DESCRIPTION
## Summary
- `mpdist_profile` previously grew the user's vector with `append!(T, zeros(TT, pad))` zero padding, silently corrupting the caller's array. `snippets` inherited the same bug since it calls `mpdist_profile` internally.
- Pad a `copy(T)` instead. The earlier comment "vcat was not type stable" still applies, so we stick with `append!` on a fresh copy.
- Added a regression test asserting `length(T)` (and contents) are unchanged across `mpdist_profile` and `snippets`.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (43/43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)