### PR TITLE
Cover final S-block in mpdist_profile outer loop (B2)

### DIFF
--- a/src/mpdist.jl
+++ b/src/mpdist.jl
@@ -43,8 +43,9 @@ function mpdist_profile(T::AbstractVector{TT},S::Int, m::Int, d::DT = ZEuclidean
     sliding_means = similar(D)
     m_profile = similar(D, 2N)
 
-    prog = Progress((n-S)÷S, dt=1, desc="MP dist profile")
-    map(1:S:n-S) do i
+    last_start = length(T) - S + 1
+    prog = Progress(length(1:S:last_start), dt=1, desc="MP dist profile")
+    map(1:S:last_start) do i
         dp = mpdist_profile(getwindow(T,S,i), T, m, d, D, sliding_means, m_profile)
         next!(prog)
         dp

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,8 +156,12 @@ end
        @test mpdist(A,A, m) < 10sqrt(eps())
        @test mpdist(B,B, m) < 10sqrt(eps())
        T = [A; B]
-       p = mpdist_profile(T, 50, 5)
+       n_T = length(T)
+       S_in = 50
+       p = mpdist_profile(T, S_in, 5)
        @test_nowarn plot(p)
+       # mpdist_profile must cover every S-sized block of the (zero-padded) series.
+       @test length(p) == cld(n_T, S_in)
 
        snips = snippets(T, 2, 50, m=5)
        @test_nowarn plot(snips)


### PR DESCRIPTION
## Summary
- `mpdist_profile(T, S, m, …)` iterated `1:S:n-S` where `n` is the original (pre-padding) length, silently dropping the trailing window even though the function pads `T` to a multiple of `S` precisely to make the last block reachable.
- Example: `n=402`, `S=50`, padded length 450 → old returned 8 profiles, new returns the expected 9.
- Switched to `1:S:length(T)-S+1` (post-padding) and used `length(1:S:last_start)` for the progress count.

## Test plan
- [x] Added regression: `length(mpdist_profile(T, S, m)) == cld(length(T), S)`
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (42/42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)