### PR TITLE
Drop n>2m+1 self-join check in generic AB-join (B3)

### DIFF
--- a/src/MatrixProfile.jl
+++ b/src/MatrixProfile.jl
@@ -131,7 +131,9 @@ function matrix_profile(A::AbstractArray{S}, B::AbstractArray{S}, m::Int, dist; 
     n  = lastlength(A)
     l  = n-m+1
     lT = lastlength(B)-m+1
-    n > 2m+1 || throw(ArgumentError("Window length too long, maximum length is $((n+1)÷2)"))
+    # The 2m+1 lower bound applies only to the self-join; for an AB-join A
+    # is independent of B and can be as short as m. See the ZEuclidean
+    # AB-join above for the same reason.
     P    = distance_profile(dist, getwindow(A,m,1), B)
     # P[1] = typemax(eltype(P))
     D    = similar(P)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,6 +88,12 @@ end
        # Test generic between two series
        profile4 = @inferred matrix_profile(T, T, length(y0), normdist)
        @test all(profile4.P .< 1e-6)
+
+       # Regression: generic AB-join must accept a short A (n <= 2m+1).
+       # A short query is a perfectly valid mutual matrix-profile use case.
+       m = length(y0)
+       short_A = T[51:51+m+1]                # length m+2, well below 2m+1
+       @test_nowarn matrix_profile(short_A, T, m, normdist)
    end
 
 


### PR DESCRIPTION
## Summary
- `matrix_profile(A::AbstractArray, B::AbstractArray, m, dist)` (generic-distance AB-join) threw `ArgumentError("Window length too long, …")` whenever `length(A) <= 2m+1`. That 2m+1 bound is a *self-join* constraint and has no business gating an AB-join — A and B are independent series, and A can legitimately be a short query against a longer target.
- The optimized ZEuclidean AB-join (line 68 in the original) already has this check commented out for the same reason; the generic-distance variant just drifted.
- Removed the throw; added a regression test running the generic AB-join with `length(A) == m+2`.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (42/42)
- [x] New regression test exercises a short-A AB-join end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)