### PR TITLE
Fix off-by-one in motifs while-loop bounds (B4)

### DIFF
--- a/src/motifs.jl
+++ b/src/motifs.jl
@@ -47,7 +47,7 @@ function motifs(p::Profile, k, found_motifs = Motif[]; r=2, th = p.m, dist = ZEu
     perm = sortperm(P)
     onsets = [perm[1]]
     j = 2
-    while P[perm[j]] < (d + 1e-5)*r && j < length(perm)
+    while j <= length(perm) && P[perm[j]] < (d + 1e-5)*r
         all(abs.(perm[j] .- onsets) .> th) && push!(onsets, perm[j])
         j += 1
     end


### PR DESCRIPTION
## Summary
- `motifs` had `while P[perm[j]] < (d + 1e-5)*r && j < length(perm)`. Because `&&` short-circuits left-to-right and the bounds clause was *second*, once `j == length(perm)` the body was never entered and the final sorted candidate was silently dropped — even when its distance was below threshold and it satisfied the `th` separation constraint.
- Reordered to `j <= length(perm) && P[perm[j]] < (d + 1e-5)*r` so the bounds check runs first (still safe) and the last candidate gets evaluated.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (41/41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)