### PR TITLE
Use passed-in distance in mpdistmat! (B5)

### DIFF
--- a/src/mpdist.jl
+++ b/src/mpdist.jl
@@ -91,7 +91,7 @@ end
 function mpdistmat!(D, A::AbstractVector, B::AbstractVector, m::Int, d)
     N = lastlength(B)-m +1
     Threads.@threads for i = 1:N # Not thread safe for more than one FFTW thread
-        distance_profile!(D[!,i], ZEuclidean(), getwindow(B, m, i), A)
+        distance_profile!(D[!,i], d, getwindow(B, m, i), A)
     end
     D
 end


### PR DESCRIPTION
## Summary
- `mpdistmat!(D, A, B, m, d)` accepted a distance argument `d` but then ignored it, hard-coding `ZEuclidean()` inside the `distance_profile!` call.
- `mpdist_profile` forwards its `d` here, so any caller passing a custom distance to `mpdist_profile` silently got z-normalized Euclidean instead.
- One-line fix: pass `d` through.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (41/41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)