### PR TITLE
Allow _dampf! to prune at the tail of T (B6)

### DIFF
--- a/src/MatrixProfile.jl
+++ b/src/MatrixProfile.jl
@@ -303,7 +303,7 @@ function _dampf!(T, m, i, BSF, PV)
     start = i + m
     last = min(start + lookahead - 1, length(T))
 
-    if last < length(T)#  && i+m-1 <= length(T) #the search does not reach the end of the time series
+    if last - start + 1 >= m # at least one full subsequence in the lookahead
         @views Di = mass(T[i:i+m-1], T[start:last])
         indices = findall(Di .< BSF)
         indices .+= (start - 1)


### PR DESCRIPTION
## Summary
- `_dampf!` guards pruning with `if last < length(T)`. But `last` is already `min(start + lookahead - 1, length(T))` on the previous line, so the equality case is the *normal* terminal condition, not an error — and the guard silently disables forward pruning for the entire tail of the series.
- Replace with `last - start + 1 >= m`, which is the actual precondition for the `mass` call (at least one full subsequence in the lookahead slice).

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (41/41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)