### PR TITLE
Exclude query's first sample from damp backward search (B7)

### DIFF
--- a/src/MatrixProfile.jl
+++ b/src/MatrixProfile.jl
@@ -267,15 +267,15 @@ function _dampb(T,m,i,BSF)
     aMPi = Inf
     prefix = nextpow(2, m) # Initial length of prefix
     @views while aMPi ≥ BSF
-        if i-prefix+1 <= 1 #the search reaches the beginning of the time series
-            aMPi = minimum(mass(T[i:i+m-1], T[1:i]))
+        if i-prefix < 1 #the search reaches the beginning of the time series
+            aMPi = minimum(mass(T[i:i+m-1], T[1:i-1]))
             if aMPi > BSF # Update the current best discord score
                 BSF = aMPi
             end
             break
         else
             # @show length(T), prefix, i, m
-            aMPi = minimum(mass(T[i:i+m-1], T[i-prefix+1:i]))
+            aMPi = minimum(mass(T[i:i+m-1], T[i-prefix:i-1]))
             if aMPi < BSF
                 break # Stop searching
             else # Double the length of prefix


### PR DESCRIPTION
## Summary
- `_dampb` compared query `T[i:i+m-1]` against ranges ending at index `i` (`T[1:i]` and `T[i-prefix+1:i]`). The last candidate in either range was therefore `T[i-m+1:i]`, which shares index `i` with the query — a forced one-sample trivial overlap that pulls the discord score down. DAMP is supposed to compare strictly against past data.
- Shift both ranges by one (`T[1:i-1]` and `T[i-prefix:i-1]`). Each window keeps its original length `prefix` so `mass`'s size preconditions are preserved. The boundary condition `i-prefix+1 <= 1` becomes the equivalent `i-prefix < 1`.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (41/41); the damp anomaly-detection test still locates the injected anomaly within `atol=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)