### PR TITLE
Clamp mpdist default k to at least 1 (B8)

### DIFF
--- a/src/mpdist.jl
+++ b/src/mpdist.jl
@@ -5,7 +5,7 @@
 
 The MP distance between `A` and `B` using window length `M` and returning the `k`th smallest value.
 """
-function mpdist(A,B,m,d=ZEuclidean(),k=(length(A)+length(B)-2m)÷20)
+function mpdist(A,B,m,d=ZEuclidean(),k=max(1, (length(A)+length(B)-2m)÷20))
     p1 = matrix_profile(A,B,m,d)
     p2 = matrix_profile(B,A,m,d)
     partialsort([p1.P; p2.P], k)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,6 +155,10 @@ end
        @test @inferred(mpdist(A,B, m)) > 0
        @test mpdist(A,A, m) < 10sqrt(eps())
        @test mpdist(B,B, m) < 10sqrt(eps())
+
+       # Regression: short inputs send default k to 0; mpdist must not error.
+       short = randn(10)
+       @test_nowarn mpdist(short, short, 4)
        T = [A; B]
        p = mpdist_profile(T, 50, 5)
        @test_nowarn plot(p)


### PR DESCRIPTION
## Summary
- The default `k = (length(A)+length(B)-2m) ÷ 20` produces 0 (or negative) for sufficiently small inputs. `partialsort(_, 0)` then throws, so `mpdist(A, B, m)` errors instead of returning a value.
- Wrap with `max(1, …)`. Added a regression `@test_nowarn mpdist(short, short, 4)` with `length(short)=10`.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (42/42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)