### PR TITLE
Make snippets th kwarg an opt-in, paper-faithful spacing extension (B10)

### DIFF
--- a/src/mpdist.jl
+++ b/src/mpdist.jl
@@ -99,12 +99,22 @@ end
 
 
 """
-    snippets(T, k, S; m = max(S ÷ 10, 4))
+    snippets(T, k, S, d = ZEuclidean(); m = max(S ÷ 10, 4), th = Inf)
 
-Summarize time series `T` by extracting `k` snippets of length `S`
-The parameter `m` controls the window length used internally.
+Summarize time series `T` by extracting `k` snippets of length `S` using
+the Snippet-Finder algorithm of Imani et al., *Matrix Profile XIII*.
+
+# Keyword arguments
+- `m`: window length used internally by `mpdist_profile`.
+- `th`: **non-standard extension** to the paper. When `th < Inf`, each
+  newly selected snippet onset is required to be more than `th` samples
+  away from every previously selected onset. The default `Inf` disables
+  the constraint and reproduces the paper's algorithm verbatim (Table I,
+  line 7). Use a finite `th` only if you specifically want to force a
+  minimum temporal spacing between snippets — it is not part of
+  Snippet-Finder as published.
 """
-function snippets(T, k, S, d=ZEuclidean(); m = max(S÷10, 4), th=S)
+function snippets(T, k, S, d=ZEuclidean(); m = max(S÷10, 4), th=Inf)
     D      = mpdist_profile(T,S,m,d)
     INF    = typemax(floattype(T))
     Q      = fill(INF, length(D[1]))
@@ -112,11 +122,12 @@ function snippets(T, k, S, d=ZEuclidean(); m = max(S÷10, 4), th=S)
     minI   = 0
     onsets = zeros(Int, k)
     snippet_profiles = similar(D, k)
+    constrain_spacing = th < Inf
     for j = 1:k
         minA = INF
         for i = 1:length(D)
             A = sum(min.(D[i], Q))
-            if A < minA #&& all(abs.(((i-1)*S+1) .- onsets[1:j-1]) .> th)
+            if A < minA && (!constrain_spacing || all(abs.(((i-1)*S+1) .- onsets[1:j-1]) .> th))
                 minA = A
                 minI = i
             end


### PR DESCRIPTION
## Summary
The original \`snippets\` function exposed a \`th=S\` kwarg that did nothing — the only line that would have read it (a predicate forcing each picked snippet to be at least \`th\` samples from previously chosen ones) was commented out.

After re-reading the **Snippet-Finder** algorithm in *Matrix Profile XIII: Time Series Snippets* (Imani, Madrid, Ding, Crouter, Keogh — IEEE Big Knowledge 2018, [PDF](https://www.cs.ucr.edu/~eamonn/Time_Series_Snippets_10pages.pdf), Table I), line 7 of the published algorithm is just \`if minimumArea > ProfileArea\` — **there is no spacing clause**. So uncommenting the predicate unconditionally would have moved the function *away* from the paper.

Instead:

- Default \`th = Inf\` → predicate is bypassed and the loop reproduces Snippet-Finder verbatim.
- Pass any finite \`th\` → opt in to the (non-paper) spacing constraint.
- Cache the \`th < Inf\` decision once before the loop so the hot path doesn't pay for an \`isfinite\` check per candidate.
- Docstring expanded; \`th\` is explicitly flagged as a non-standard extension.

## Test plan
- [x] \`julia --project -e 'using Pkg; Pkg.test()'\` passes (41/41) — default behaviour unchanged for existing callers (\`snippets(T, 2, 50, m=5)\` still works since \`Inf\` skips the predicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)