### PR TITLE
Docstring / typo cleanup (B12)

### DIFF
--- a/src/MatrixProfile.jl
+++ b/src/MatrixProfile.jl
@@ -252,16 +252,19 @@ end
 
 
 """
-    aMP[i], BSF = dampb(T, m, i, BSF)
+    aMPi, BSF = _dampb(T, m, i, BSF)
 
 Backward processing of damp algorithm
 
 # Arguments:
 - `T`: Time series
-- `m`: Subsequence
+- `m`: Subsequence length
 - `i`: Index of current query
 - `BSF`: Highest discord score so far
+
+# Returns:
 - `aMPi`: Discord value at position i
+- `BSF`: Possibly updated best-so-far discord score
 """
 function _dampb(T,m,i,BSF)
     aMPi = Inf

--- a/src/mpdist.jl
+++ b/src/mpdist.jl
@@ -1,9 +1,9 @@
 
 
 """
-    mpdist(A, B, m, d = ZEuclidean, k = ((length(A) + length(B)) - 2m) ÷ 20)
+    mpdist(A, B, m, d = ZEuclidean(), k = ((length(A) + length(B)) - 2m) ÷ 20)
 
-The MP distance between `A` and `B` using window length `M` and returning the `k`th smallest value.
+The MP distance between `A` and `B` using window length `m` and returning the `k`th smallest value.
 """
 function mpdist(A,B,m,d=ZEuclidean(),k=(length(A)+length(B)-2m)÷20)
     p1 = matrix_profile(A,B,m,d)
@@ -33,7 +33,7 @@ end
 All MP distance profiles between subsequences of length `S` in `T` using internal window length `m`.
 """
 function mpdist_profile(T::AbstractVector{TT},S::Int, m::Int, d::DT = ZEuclidean()) where {TT,DT}
-    S >= m || throw(ArgumentError("S should be > m"))
+    S >= m || throw(ArgumentError("S should be ≥ m"))
     SlidingDistancesBase.DSP.FFTW.set_num_threads(1)
     n = length(T)
     pad = S * ceil(Int, n / S) - n

--- a/src/segment.jl
+++ b/src/segment.jl
@@ -29,7 +29,7 @@ end
 """
     i = segment(p::Profile)
 
-Returns an index `i` indicating the most likely segmentation point of profile `p`, i.e., the point which the fewst nearest-neighbor arcs passes over.
+Returns an index `i` indicating the most likely segmentation point of profile `p`, i.e., the point which the fewest nearest-neighbor arcs passes over.
 
 Ref: Matrix Profile VIII: Domain Agnostic Online Semantic
 Segmentation at Superhuman Performance Levels

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,7 +179,7 @@ end
 
         x = [sin.(1:0.1:100); sign.(sin.(1:0.1:100))]
         x .+= 0.01 .* randn.()
-        p = p = matrix_profile(x, 20)
+        p = matrix_profile(x, 20)
         s = segment_profile(p)
         val, ind = findmin(s)
         @test abs(ind-length(s)÷2) < 10


### PR DESCRIPTION
## Summary
Consolidated bundle of small docstring and typo fixes uncovered during the review:

- `src/mpdist.jl`: docstring `d = ZEuclidean` → `ZEuclidean()`; signature param `m` matched in prose (was "window length M").
- `src/mpdist.jl`: `ArgumentError("S should be > m")` aligned with the actual `S >= m` check by changing the message to `S should be ≥ m`.
- `src/MatrixProfile.jl`: `_dampb` docstring used the wrong function name (`dampb`); `aMPi` was listed under "Arguments" but is a return. Moved to a "Returns" section; clarified `m` as a subsequence length.
- `src/segment.jl`: "fewst" → "fewest".
- `test/runtests.jl`: drop the accidental double-assignment `p = p = matrix_profile(x, 20)`.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (41/41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)