### PR TITLE
Make mpdist_profile loop match paper's floor(n/S) (B2)

### DIFF
--- a/src/mpdist.jl
+++ b/src/mpdist.jl
@@ -38,15 +38,17 @@ function mpdist_profile(T::AbstractVector{TT},S::Int, m::Int, d::DT = ZEuclidean
     SlidingDistancesBase.DSP.FFTW.set_num_threads(1)
     try
         n = length(T)
-        pad = S * ceil(Int, n / S) - n
-        T = append!(copy(T), zeros(TT, pad)) # copy() to avoid mutating caller; vcat was not type stable
+        # Imani et al., Matrix Profile XIII, Table II: floor(n/S) non-overlapping
+        # windows T[(i-1)S+1 : iS]; trailing n mod S samples are not used.
+        n_windows = n ÷ S
+        last_start = (n_windows - 1) * S + 1
         N = S-m+1
-        D = Matrix{float(TT)}(undef, length(T)-m+1, N)
+        D = Matrix{float(TT)}(undef, n-m+1, N)
         sliding_means = similar(D)
         m_profile = similar(D, 2N)
 
-        prog = Progress((n-S)÷S, dt=1, desc="MP dist profile")
-        map(1:S:n-S) do i
+        prog = Progress(n_windows, dt=1, desc="MP dist profile")
+        map(1:S:last_start) do i
             dp = mpdist_profile(getwindow(T,S,i), T, m, d, D, sliding_means, m_profile)
             next!(prog)
             dp

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,8 +160,11 @@ end
        short = randn(10)
        @test_nowarn mpdist(short, short, 4)
        T = [A; B]
-       p = mpdist_profile(T, 50, 5)
+       S_in = 50
+       p = mpdist_profile(T, S_in, 5)
        @test_nowarn plot(p)
+       # Imani et al., Matrix Profile XIII, Table II: floor(n/S) windows.
+       @test length(p) == length(T) ÷ S_in
 
        snips = snippets(T, 2, 50, m=5)
        @test_nowarn plot(snips)


### PR DESCRIPTION
## Summary

Replaces #21 with a paper-faithful fix. Imani et al., *Matrix Profile XIII: Time Series Snippets*, Table II specifies:

```
for i = 1:n/m
   D ← Profile(T, T[(i-1)*m + 1 : i*m])
end
```

The window `T[(i-1)S+1 : iS]` requires `iS ≤ n`, so the literal reading is `floor(n/S)` non-overlapping segments and any trailing `n mod S` samples are dropped. The paper never zero-pads `T`.

Master's behavior was inconsistent with the paper in two ways:
- It padded `T` to `S*ceil(n/S)` but iterated `1:S:n-S` against the **pre-padded** length, so the padding was dead code.
- On exact multiples of `S`, it dropped a segment (e.g. `n=400, S=50` → 7 profiles, paper says 8).

#21 went the other direction — kept the padding and iterated over the padded tail, producing `ceil(n/S)` profiles where the final one is computed over a window with a zero-padded tail (matched against a `T` that is also zero-padded, so the zero suffix matches itself and biases the result).

This PR drops the padding entirely and uses `1:S:(n_windows-1)*S+1` with `n_windows = n ÷ S`. The trailing `n mod S` samples are dropped exactly as the paper specifies.

## Test plan
- [x] Regression added: `length(mpdist_profile(T, S, m)) == length(T) ÷ S`
- [x] Existing "must not mutate caller's `T`" test still passes (now trivially — the new code never touches `T`)
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes 46/46

🤖 Generated with [Claude Code](https://claude.com/claude-code)